### PR TITLE
- made exports more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "fs-extra": "^0.30.0",
-    "react-hot-loader": "^1.3.0"
+    "react-hot-loader": "^1.3.0",
+    "webpack": "^1.13.1"
   },
   "dependencies": {
     "core-decorators": "^0.12.2",

--- a/src/JXGBoard/FunctionGraph/Antiderivative/index.js
+++ b/src/JXGBoard/FunctionGraph/Antiderivative/index.js
@@ -1,1 +1,1 @@
-export * from './Antiderivative';
+export { Antiderivative } from './Antiderivative';

--- a/src/JXGBoard/FunctionGraph/Integral/index.js
+++ b/src/JXGBoard/FunctionGraph/Integral/index.js
@@ -1,1 +1,1 @@
-export * from './Integral';
+export { Integral } from './Integral';

--- a/src/JXGBoard/FunctionGraph/index.js
+++ b/src/JXGBoard/FunctionGraph/index.js
@@ -1,6 +1,6 @@
 //self
-export * from './FunctionGraph';
+export { FunctionGraph } from './FunctionGraph';
 
 //children
-export * from './Antiderivative';
-export * from './Integral';
+export { Antiderivative } from './Antiderivative';
+export { Integral } from './Integral';

--- a/src/JXGBoard/index.js
+++ b/src/JXGBoard/index.js
@@ -1,5 +1,5 @@
 //self
-export * from './JXGBoard';
+export { JXGBoard } from './JXGBoard';
 
 //children
-export * from './FunctionGraph';
+export { FunctionGraph, Antiderivative, Integral } from './FunctionGraph';

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export * from './JXGBoard';
+export { JXGBoard, FunctionGraph, Integral, Antiderivative } from './JXGBoard';


### PR DESCRIPTION
- changed export scheme to be more explicit
- added webpack as a devDependency because react-hot-loader/babel-loader list it as a peer dependency (not really necessary though)
